### PR TITLE
Merge feat/1.3.0 into master

### DIFF
--- a/app-extension/package.json
+++ b/app-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quasar-app-extension-linkage-cms-ui",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A Quasar App Extension",
   "author": "Robby <ta7382@gmail.com>",
   "license": "MIT",
@@ -12,7 +12,7 @@
   "bugs": "https://github.com/LinkageRetail/quasar-app-extension-boilerplate/issues",
   "homepage": "https://github.com/LinkageRetail/quasar-app-extension-boilerplate",
   "dependencies": {
-    "quasar-ui-linkage-cms-ui": "^1.2.1"
+    "quasar-ui-linkage-cms-ui": "^1.3.0"
   },
   "engines": {
     "node": ">= 10.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkage-cms-ui",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": "Robby <ta7382@gmail.com>",
   "description": "Linkage CMS UI",
   "license": "MIT",

--- a/ui/dev/src/pages/BaseLayout.vue
+++ b/ui/dev/src/pages/BaseLayout.vue
@@ -8,8 +8,13 @@
         <!-- Add some templates -->
       </template>
 
+      <template #buttons>
+        <q-btn unelevated color="primary" label="Button" />
+        <!-- Add some templates -->
+      </template>
+
       <template #search>
-        search
+        <div class="col-12 col-sm-4 col-md-3 q-gutter-y-xs">search</div>
         <!-- Add some templates -->
       </template>
 

--- a/ui/dev/src/pages/DetailLayout.vue
+++ b/ui/dev/src/pages/DetailLayout.vue
@@ -6,6 +6,43 @@
         <!-- Add some templates -->
       </template>
 
+      <template #navs-buttons>
+        <q-btn unelevated color="primary" label="Button" />
+        <!-- Add some templates -->
+      </template>
+
+      <template #buttons>
+        buttons
+        <!-- Add some templates -->
+      </template>
+
+      <template #section-left>
+        section-left
+        <!-- Add some templates -->
+      </template>
+
+      <template #section-right>
+        section-right
+        <!-- Add some templates -->
+      </template>
+
+      <template #section-bottom>
+        section-bottom
+        <!-- Add some templates -->
+      </template>
+    </DetailLayout>
+
+    <DetailLayout title="DetailLayout Example" search :top-rows="{ md: [6, 6], lg: [7, 5] }">
+      <template #navs>
+        navs
+        <!-- Add some templates -->
+      </template>
+
+      <template #navs-buttons>
+        <q-btn unelevated color="primary" label="Button" />
+        <!-- Add some templates -->
+      </template>
+
       <template #buttons>
         buttons
         <!-- Add some templates -->

--- a/ui/dev/src/pages/DetailListLayout.vue
+++ b/ui/dev/src/pages/DetailListLayout.vue
@@ -6,7 +6,7 @@
     </template>
 
     <template #buttons>
-      buttons
+      <q-btn unelevated color="primary" label="Button" />
       <!-- Add some templates -->
     </template>
 

--- a/ui/dev/src/pages/DetailTreeLayout.vue
+++ b/ui/dev/src/pages/DetailTreeLayout.vue
@@ -11,7 +11,7 @@
     </template>
 
     <template #buttons>
-      buttons
+      <q-btn unelevated color="primary" label="Button" />
       <!-- Add some templates -->
     </template>
 

--- a/ui/dev/src/pages/Table.vue
+++ b/ui/dev/src/pages/Table.vue
@@ -13,6 +13,20 @@
         </q-tr>
       </template>
     </Table>
+
+    <Table class="q-mt-xl" selection="none" table-header-dark :columns="columns" v-model="datas">
+      <template #body="props">
+        <q-tr>
+          <q-td key="userId">{{ props.row.userId }}</q-td>
+          <q-td key="customerNo"> {{ props.row.customerNo }}</q-td>
+          <q-td key="customerName">{{ props.row.firstName }} {{ props.row.lastName }}</q-td>
+          <q-td key="phoneNo">
+            <div>{{ props.row.phoneNo }}</div>
+            <div>{{ props.row.email }}</div>
+          </q-td>
+        </q-tr>
+      </template>
+    </Table>
   </q-page>
 </template>
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quasar-ui-linkage-cms-ui",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": "Robby <ta7382@gmail.com>",
   "description": "Linkage CMS UI",
   "license": "MIT",

--- a/ui/src/components/Dialog/ImageUpload.vue
+++ b/ui/src/components/Dialog/ImageUpload.vue
@@ -43,7 +43,7 @@
         <q-btn label="Cancel" color="grey" @click="hide" />
         <q-btn
           label="Insert"
-          color="blue"
+          color="primary"
           :disable="payload.src === ''"
           :loading="loading"
           @click="onDebugUpload"

--- a/ui/src/components/FileUpload.vue
+++ b/ui/src/components/FileUpload.vue
@@ -5,7 +5,7 @@
   <q-uploader
     ref="uploader"
     class="full-width"
-    color="green-custom-1"
+    color="primary"
     square
     flat
     bordered

--- a/ui/src/components/FormDialog.vue
+++ b/ui/src/components/FormDialog.vue
@@ -90,7 +90,7 @@ export default {
     padding-bottom: 2rem;
     height: 40px;
     color: #fff;
-    background-color: $primary;
+    background-color: var(--q-color-primary);
 
     > span {
       padding-bottom: 0.25rem;

--- a/ui/src/components/Table.vue
+++ b/ui/src/components/Table.vue
@@ -37,6 +37,7 @@
   <q-table
     ref="table"
     :row-key="rowKey"
+    :class="tableHeaderDark && 'table-header-dark'"
     :table-header-class="tableHeaderClass"
     :flat="flat"
     :hide-bottom="hideBottom"
@@ -59,7 +60,7 @@
           :key="`sort-${sort}`"
           outline
           class="q-ml-sm q-pa-xs text-body2"
-          color="blue"
+          color="primary"
         >
           {{ sort }}
           <q-icon v-show="sortMap_[sort]" name="south" />
@@ -114,6 +115,11 @@ export default {
       // 強烈建議不要使用, 如果使用了, 請留意後續 filter, pagination 問題
       type: [Number, String, Array, Object],
       default: null, // 自行創建 request 參數 { filter, pagination... }
+    },
+    filterKey: {
+      // 發出請求時, request payload 的 filter key name, legacy 專案出現了其他自定義的 key, 因此需要支持
+      type: String,
+      default: 'filter',
     },
     selected: {
       type: Array,
@@ -194,6 +200,11 @@ export default {
     tableHeaderClass: {
       type: String,
       default: '',
+    },
+    tableHeaderDark: {
+      // 如果為 true, 則套用 class='table-header-dark'
+      type: Boolean,
+      default: false,
     },
     flat: {
       type: Boolean,
@@ -357,7 +368,7 @@ export default {
             };
           } else {
             params = {
-              filter,
+              [this.filterKey]: filter,
               paging: { page, size, sortBy: sortBy || this.defaultSortBy, descending },
             };
           }

--- a/ui/src/components/Table.vue
+++ b/ui/src/components/Table.vue
@@ -549,3 +549,12 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.table-header-dark {
+  ::v-deep thead tr {
+    color: #fff;
+    background-color: var(--q-color-primary);
+  }
+}
+</style>

--- a/ui/src/components/layouts/Section/BaseLayout.vue
+++ b/ui/src/components/layouts/Section/BaseLayout.vue
@@ -84,11 +84,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'quasar/src/css/variables.sass';
-
 .wrapper {
   padding: 30px;
-  color: $primary;
+  color: var(--q-color-primary);
 }
 
 .head {
@@ -97,7 +95,7 @@ export default {
 
   .title {
     font-size: 20px;
-    border-bottom: 3px solid $primary;
+    border-bottom: 3px solid var(--q-color-primary);
   }
 
   .buttons {

--- a/ui/src/components/layouts/Section/DetailLayout.vue
+++ b/ui/src/components/layouts/Section/DetailLayout.vue
@@ -20,7 +20,15 @@
       <div class="section">
         <div class="row q-col-gutter-x-md" v-if="$slots['section-right']">
           <!-- Section left -->
-          <div class="col-12 col-lg-9 col-md-8 section-left">
+          <div
+            class="col-12 section-left"
+            :class="[
+              `${topRows.lg && `col-lg-${topRows.lg[0]}`}`,
+              `${topRows.md && `col-md-${topRows.md[0]}`}`,
+              `${topRows.sm && `col-sm-${topRows.sm[0]}`}`,
+              `${topRows.xs && `col-xs-${topRows.xs[0]}`}`,
+            ]"
+          >
             <q-card flat bordered>
               <q-card-section class="section-group">
                 <!-- Slot section-left -->
@@ -42,7 +50,15 @@
             </q-card>
           </div>
           <!-- Section right -->
-          <div class="col-12 col-lg-3 col-md-4 section-right">
+          <div
+            class="col-12 section-right"
+            :class="[
+              `${topRows.lg && `col-lg-${topRows.lg[1]}`}`,
+              `${topRows.md && `col-md-${topRows.md[1]}`}`,
+              `${topRows.sm && `col-sm-${topRows.sm[1]}`}`,
+              `${topRows.xs && `col-xs-${topRows.xs[1]}`}`,
+            ]"
+          >
             <q-card flat bordered>
               <q-card-section class="section-group row justify-between" style="height: 100%">
                 <!-- Slot section-right -->
@@ -112,6 +128,14 @@ export default {
     buttons: {
       type: Boolean,
       default: true,
+    },
+    topRows: {
+      /**
+       * 頂部 Section 區塊的左右格子數
+       * @example ({ md: [9, 3], lg: [8, 4] })
+       */
+      type: Object,
+      default: () => ({ md: [9, 3], lg: [8, 4] }),
     },
   },
   components: {

--- a/ui/src/components/layouts/Section/DetailTreeLayout.vue
+++ b/ui/src/components/layouts/Section/DetailTreeLayout.vue
@@ -224,8 +224,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import 'quasar/src/css/variables.sass';
-
 .section {
   > div.row {
     padding-bottom: 0.5rem;
@@ -272,7 +270,7 @@ export default {
 // Tree node
 .tree {
   overflow: auto;
-  color: $primary;
+  color: var(--q-color-primary);
 }
 
 ::v-deep .q-tree__arrow {

--- a/ui/src/vue-plugin.js
+++ b/ui/src/vue-plugin.js
@@ -34,14 +34,14 @@ import PopupSelect from './components/Input/PopupSelect.vue';
 
 //#region Layout
 
-import AdminLayout from './components/layouts/AdminLayout.vue';
+import AdminLayout from './components/Layouts/AdminLayout.vue';
 
-import Menu from './components/layouts/Menu.vue';
+import Menu from './components/Layouts/Menu.vue';
 
-import BaseLayout from './components/layouts/Section/BaseLayout.vue';
-import DetailLayout from './components/layouts/Section/DetailLayout.vue';
-import DetailListLayout from './components/layouts/Section/DetailListLayout.vue';
-import DetailTreeLayout from './components/layouts/Section/DetailTreeLayout.vue';
+import BaseLayout from './components/Layouts/Section/BaseLayout.vue';
+import DetailLayout from './components/Layouts/Section/DetailLayout.vue';
+import DetailListLayout from './components/Layouts/Section/DetailListLayout.vue';
+import DetailTreeLayout from './components/Layouts/Section/DetailTreeLayout.vue';
 
 //#endregion
 


### PR DESCRIPTION
# Changelog

- 調整組件預設顏色 primary
- 增加 DetailLayout 屬性 `topRows`
- 增加 Table 屬性 `tableHeaderDark`
- 將 $primary 改為使用 rootStyle `var(--q-color-primary)`
- 將 layouts 目錄改名統一大寫 Layouts


### DetailLayout `topRows`

下方第二個 Layout 為使用結果

```html
<DetailLayout title="DetailLayout Example" search :top-rows="{ md: [6, 6], lg: [7, 5] }">
```

![截圖 2022-04-01 下午12 21 27](https://user-images.githubusercontent.com/72367384/161194404-0195e3b8-40b7-4947-9713-33f7cbedb6d9.png)

### Table `tableHeaderDark`

下方第二個 Layout 為使用結果

```html
<Table class="q-mt-xl" selection="none" table-header-dark :columns="columns" v-model="datas">
```

![截圖 2022-04-01 下午12 22 09](https://user-images.githubusercontent.com/72367384/161194462-bf576bd7-77ff-4044-b892-12f82d2fd98f.png)



